### PR TITLE
Rename squid to squid-cache and add caching tests

### DIFF
--- a/squid-cache/squid-cache.sh
+++ b/squid-cache/squid-cache.sh
@@ -43,7 +43,7 @@ ensure_dirs() {
 }
 
 cache_dir_pick() {
-  if [ -x "$BASE_DIR/squid" ]; then
+  if [ -x "$BASE_DIR/squid-cache" ]; then
     echo "$CACHE_IF_STANDALONE_BIN"
   else
     echo "$CACHE_IF_SYSTEM"
@@ -140,7 +140,7 @@ iptables_disable() {
     while iptables -t nat -S "$IPTABLES_CHAIN" | grep -q "^-A $IPTABLES_CHAIN"; do
       local rule
       rule="$(iptables -t nat -S "$IPTABLES_CHAIN" | grep "^-A $IPTABLES_CHAIN" | head -n1 | sed 's/^-A /-D /')"
-      iptables -t nat $rule || true
+      iptables -t nat "$rule" || true
     done
     iptables -t nat -X "$IPTABLES_CHAIN" || true
   fi

--- a/squid-cache/tests/00_start_iptables_cert.sh
+++ b/squid-cache/tests/00_start_iptables_cert.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+[ "$("$SQUID" start)" = "started" ]
+iptables -t nat -S | grep -q SQUID_LOCAL
+[ -f /usr/local/share/ca-certificates/squid-mitm.crt ]
+[ "$("$SQUID" stop)" = "stopped" ]

--- a/squid-cache/tests/01_cache_behavior.sh
+++ b/squid-cache/tests/01_cache_behavior.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+[ "$("$SQUID" start)" = "started" ]
+u1="https://speed.hetzner.de/200MB.bin"
+u2="https://speed.hetzner.de/1GB.bin"
+cache=/tmp/squid-cache
+s=$(date +%s)
+curl -L -o /dev/null "$u1"
+e=$(date +%s)
+t1=$((e-s))
+s=$(date +%s)
+curl -L -o /dev/null "$u2"
+e=$(date +%s)
+t2=$((e-s))
+c=$(find "$cache" -type f | wc -l)
+[ "$c" -ge 2 ]
+s=$(date +%s)
+curl -L -o /dev/null "$u1"
+e=$(date +%s)
+t3=$((e-s))
+s=$(date +%s)
+curl -L -o /dev/null "$u2"
+e=$(date +%s)
+t4=$((e-s))
+[ "$t3" -lt "$t1" ]
+[ "$t4" -lt "$t2" ]
+[ "$("$SQUID" stop)" = "stopped" ]
+[ ! -f /usr/local/share/ca-certificates/squid-mitm.crt ]
+if iptables -t nat -S | grep -q SQUID_LOCAL; then false; fi
+if systemctl is-active --quiet squid; then false; fi
+c2=$(find "$cache" -type f | wc -l)
+[ "$c2" -ge "$c" ]

--- a/squid-cache/tests/AGENTS.md
+++ b/squid-cache/tests/AGENTS.md
@@ -1,0 +1,4 @@
+Use $SQUID for ../squid-cache.sh
+Scripts are bash with set -Eeuo pipefail and no comments
+Set TRACE=1 to trace test execution
+Run ../../testing/run-tests.sh . to execute all tests or pass script paths


### PR DESCRIPTION
## Summary
- rename squid to squid-cache
- add tests for squid-cache start, caching, and cleanup

## Testing
- `shellcheck osx-install/osx-install.sh testing/run-tests.sh osx-install/tests/*.sh squid-cache/squid-cache.sh squid-cache/tests/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aeac59b948832d90e0a5db654f488f