### PR TITLE
Fix squid cache test summary extraction

### DIFF
--- a/.github/workflows/squid-cache-tests.yml
+++ b/.github/workflows/squid-cache-tests.yml
@@ -11,9 +11,8 @@ jobs:
     - name: run tests
       run: |
         set -e
-        out=$(mktemp)
-        SQUID="$PWD/squid-cache/squid-cache.sh" TRACE=1 testing/run-tests.sh squid-cache/tests/00_start_iptables_cert.sh squid-cache/tests/01_cache_behavior.sh squid-cache/tests/02_python_install.sh | tee "$out"
-        line=$(grep '^t1=' "$out" | tail -n1)
+        SQUID="$PWD/squid-cache/squid-cache.sh" TRACE=1 testing/run-tests.sh squid-cache/tests/00_start_iptables_cert.sh squid-cache/tests/01_cache_behavior.sh squid-cache/tests/02_python_install.sh
+        line=$(grep '^t1=' artifacts/01_cache_behavior.log | tail -n1)
         eval "$line"
         {
           echo "first_download1=$t1"


### PR DESCRIPTION
## Summary
- read timing metrics from artifacts log to populate job summary

## Testing
- `shellcheck osx-run/osx-run.sh testing/run-tests.sh osx-run/tests/*.sh`
- `SQUID="$PWD/squid-cache/squid-cache.sh" TRACE=1 testing/run-tests.sh squid-cache/tests/00_start_iptables_cert.sh squid-cache/tests/01_cache_behavior.sh squid-cache/tests/02_python_install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aec8e481a0832d890819b2e3fc7be9