### PR TITLE
Align osx-run usage with env.txt semantics

### DIFF
--- a/osx-run/tests/00_bootstrap_skeleton.sh
+++ b/osx-run/tests/00_bootstrap_skeleton.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+"$RUN" install osxcross >/dev/null
+"$RUN" install python 3.12 >/dev/null
+"$RUN" install node 22 >/dev/null
 "$RUN" true >/dev/null
 [ -d "$OSX_ROOT/bin" ]
 [ -d "$OSX_ROOT/env" ]

--- a/osx-run/tests/02_osxcross_install_arm64_155.sh
+++ b/osx-run/tests/02_osxcross_install_arm64_155.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+"$RUN" install osxcross >/dev/null
 "$RUN" xcrun --version >/dev/null
 "$RUN" xcrun --show-sdk-path | grep -q "$OSX_ROOT/pkgs/osxcross/target/SDK"
 "$RUN" env | grep -q "SDKROOT=$OSX_ROOT/pkgs/osxcross/target/SDK"

--- a/osx-run/tests/03_osx_shims_resolution.sh
+++ b/osx-run/tests/03_osx_shims_resolution.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+"$RUN" install osxcross >/dev/null
 sdk=$("$RUN" xcrun --show-sdk-path)
 [ -n "$sdk" ]
 export SDKROOT="$sdk"

--- a/osx-run/tests/04_compile_macho_hello.sh
+++ b/osx-run/tests/04_compile_macho_hello.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 . "$OSX_ROOT/env/config.sh"
+"$RUN" install osxcross >/dev/null
 cat > hello.c <<'EOC'
 int main(){return 0;}
 EOC

--- a/osx-run/tests/05_python_install_version.sh
+++ b/osx-run/tests/05_python_install_version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+"$RUN" install python 3.12 >/dev/null
 "$RUN" python -c 'import sys;print(sys.version)' | grep -q '^3\.12\.'
 grep -q "$OSX_ROOT/site-" "$OSX_ROOT/env/pip-macos.conf"

--- a/osx-run/tests/06_pip_wheelhouse_and_site.sh
+++ b/osx-run/tests/06_pip_wheelhouse_and_site.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 . "$OSX_ROOT/env/config.sh"
+"$RUN" install python 3.12 >/dev/null
 sdk_major="${DEFAULT_SDK_VER%%.*}"
 platform="macosx_${sdk_major}_0_${DEFAULT_ARCH}"
 wh="$OSX_ROOT/wheelhouse/$platform"

--- a/osx-run/tests/07_node_install_version.sh
+++ b/osx-run/tests/07_node_install_version.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 ver=22.7.0
+"$RUN" install node 22 >/dev/null
 "$RUN" node -v | grep -q "v$ver"
 "$RUN" npm -v >/dev/null
 "$RUN" npx -v >/dev/null

--- a/osx-run/tests/08_npm_env_platform_arch.sh
+++ b/osx-run/tests/08_npm_env_platform_arch.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 . "$OSX_ROOT/env/config.sh"
+"$RUN" install node 22 >/dev/null
 out=$("$RUN" npm config list -l)
 printf '%s' "$out" | grep -q 'platform.*darwin'
 printf '%s' "$out" | grep -q "arch.*$DEFAULT_ARCH"

--- a/osx-run/tests/10_switch_current_symlinks.sh
+++ b/osx-run/tests/10_switch_current_symlinks.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+"$RUN" install python 3.12 >/dev/null
+"$RUN" install node 22 >/dev/null
 [ "$(readlink "$OSX_ROOT/pkgs/python/current")" = "$OSX_ROOT/pkgs/python/3.12.0" ]
 [ "$(readlink "$OSX_ROOT/pkgs/node/current")" = "$OSX_ROOT/pkgs/node/22.7.0" ]
 "$RUN" python -c 'import sys;print(sys.version)' | grep -q '^3\.12\.'

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -12,7 +12,10 @@ printf 'python %s\n' "$(python -V 2>&1)"
 printf 'shellcheck %s\n' "$(shellcheck --version 2>/dev/null | head -n1)"
 pass=0
 fail=0
-RUN="$(pwd)/osx-run/osx-run.sh"
+tmp_run=$(mktemp -d)
+cp osx-run/osx-run.sh "$tmp_run"
+RUN="$tmp_run/osx-run.sh"
+chmod +x "$RUN"
 export RUN
 run(){
 t="$1"
@@ -53,4 +56,5 @@ for t in "${tests[@]}"; do
 run "$t"
 done
 echo "passed $pass failed $fail"
+rm -rf "$tmp_run"
 [ "$fail" -eq 0 ]

--- a/testing/stub-env.sh
+++ b/testing/stub-env.sh
@@ -2,6 +2,11 @@
 set -Eeuo pipefail
 OSX_ROOT="$1"
 mkdir -p "$OSX_ROOT/bin" "$OSX_ROOT/env" "$OSX_ROOT/shims" "$OSX_ROOT/pkgs/osxcross/target/bin" "$OSX_ROOT/pkgs/osxcross/target/SDK" "$OSX_ROOT/pkgs/python/3.12.0/bin" "$OSX_ROOT/pkgs/node/22.7.0/bin" "$OSX_ROOT/wheelhouse/macosx_15_0_arm64" "$OSX_ROOT/site-macosx_15_0_arm64" "$OSX_ROOT/cache" "$OSX_ROOT/toolchains"
+cat > "$OSX_ROOT/bin/install" <<'EOF2'
+#!/usr/bin/env bash
+exit 0
+EOF2
+chmod +x "$OSX_ROOT/bin/install"
 cat > "$OSX_ROOT/env/config.sh" <<EOF2
 OSX_ROOT="$OSX_ROOT"
 DEFAULT_ARCH="arm64"


### PR DESCRIPTION
## Summary
- Use a temporary copy of osx-run during tests to mirror env.txt usage
- Add stub installer and update tests to call install subcommands
- Ensure node and python tests invoke installs before running tools

## Testing
- `shellcheck osx-run/osx-run.sh testing/run-tests.sh osx-run/tests/*.sh testing/stub-env.sh`
- `./testing/run-tests.sh osx-run/tests`


------
https://chatgpt.com/codex/tasks/task_e_68aecd83b82c832dbc4449648f134c8a