### PR TITLE
Call squid-cache via bash and ensure iptables availability in tests

### DIFF
--- a/squid-cache/tests/00_start_iptables_cert.sh
+++ b/squid-cache/tests/00_start_iptables_cert.sh
@@ -4,9 +4,9 @@ if ! command -v systemctl >/dev/null 2>&1; then exit 0; fi
 if ! systemctl is-system-running >/dev/null 2>&1; then exit 0; fi
 if ! command -v iptables >/dev/null 2>&1; then exit 0; fi
 o=$(mktemp)
-"$SQUID" start >"$o"
+bash "$SQUID" start >"$o"
 [ "$(tail -n1 "$o")" = started ]
 iptables -t nat -S | grep -q SQUID_LOCAL
 [ -f /usr/local/share/ca-certificates/squid-mitm.crt ]
-"$SQUID" stop >"$o"
+bash "$SQUID" stop >"$o"
 [ "$(tail -n1 "$o")" = stopped ]

--- a/squid-cache/tests/01_cache_behavior.sh
+++ b/squid-cache/tests/01_cache_behavior.sh
@@ -4,7 +4,7 @@ if ! command -v systemctl >/dev/null 2>&1; then exit 0; fi
 if ! systemctl is-system-running >/dev/null 2>&1; then exit 0; fi
 if ! command -v iptables >/dev/null 2>&1; then exit 0; fi
 o=$(mktemp)
-"$SQUID" start >"$o"
+bash "$SQUID" start >"$o"
 [ "$(tail -n1 "$o")" = started ]
 u1="https://speed.hetzner.de/200MB.bin"
 u2="https://speed.hetzner.de/1GB.bin"
@@ -29,7 +29,7 @@ e=$(date +%s)
 t4=$((e-s))
 [ "$t3" -lt "$t1" ]
 [ "$t4" -lt "$t2" ]
-"$SQUID" stop >"$o"
+bash "$SQUID" stop >"$o"
 [ "$(tail -n1 "$o")" = stopped ]
 [ ! -f /usr/local/share/ca-certificates/squid-mitm.crt ]
 if iptables -t nat -S | grep -q SQUID_LOCAL; then false; fi

--- a/squid-cache/tests/02_python_install.sh
+++ b/squid-cache/tests/02_python_install.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 systemctl is-system-running >/dev/null 2>&1 || exit 0
 o=$(mktemp)
-"$SQUID" start >"$o"
+bash "$SQUID" start >"$o"
 [ "$(tail -n1 "$o")" = started ]
 tmp=$(mktemp -d)
 apt-get update >/dev/null
@@ -10,6 +10,6 @@ apt-get download python3.11-minimal >/dev/null
 d=$(ls python3.11-minimal_*.deb)
 dpkg -x "$d" "$tmp"
 [ -x "$tmp/usr/bin/python3.11" ]
-"$SQUID" stop >"$o"
+bash "$SQUID" stop >"$o"
 [ "$(tail -n1 "$o")" = stopped ]
 rm -rf "$tmp" "$d"

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-if ! command -v shellcheck >/dev/null 2>&1 || ! command -v file >/dev/null 2>&1; then /usr/bin/sudo apt-get update; /usr/bin/sudo apt-get install -y shellcheck file; fi
+if ! command -v shellcheck >/dev/null 2>&1 || ! command -v file >/dev/null 2>&1 || ! command -v iptables >/dev/null 2>&1; then /usr/bin/sudo apt-get update; /usr/bin/sudo apt-get install -y shellcheck file iptables; fi
 mkdir -p artifacts
 printf 'bash %s\n' "$(bash --version | head -n1)"
 printf 'zsh %s\n' "$(zsh --version 2>/dev/null | head -n1)"


### PR DESCRIPTION
## Summary
- Run squid-cache script through bash in tests to match env semantics
- Install iptables when missing during test runs

## Testing
- `shellcheck osx-run/osx-run.sh testing/run-tests.sh osx-run/tests/*.sh squid-cache/tests/*.sh`
- `SQUID=squid-cache/squid-cache.sh ./testing/run-tests.sh squid-cache/tests`


------
https://chatgpt.com/codex/tasks/task_e_68aece0a1fd4832d80e9ae2b10656847