### PR TITLE
Ensure squid startup works in tests

### DIFF
--- a/squid-cache/squid-cache.sh
+++ b/squid-cache/squid-cache.sh
@@ -117,8 +117,9 @@ EOF
 
 init_ssl_db() {
   local helper="$1"
+  rm -rf "$SSL_DB_DIR"
   install -d -o "$SQUID_USER" -g "$SQUID_GROUP" "$SSL_DB_DIR"
-  su -s /bin/sh -c "$helper -c -s $SSL_DB_DIR -M 20MB" "$SQUID_USER" || true
+  su -s /bin/sh -c "$helper -c -s $SSL_DB_DIR -M 20MB" "$SQUID_USER"
 }
 
 iptables_enable() {
@@ -188,6 +189,7 @@ start() {
   if [ -f "$LOCK_FILE" ]; then exit 0; fi
   touch "$LOCK_FILE"
   install_packages
+  squid_stop
   local helper
   helper="$(detect_ssl_helper)"
   [ -n "$helper" ] || { echo "ssl helper not found"; rm -f "$LOCK_FILE"; exit 1; }

--- a/squid-cache/tests/run-tests.sh
+++ b/squid-cache/tests/run-tests.sh
@@ -44,11 +44,6 @@ else
  done
 fi
 printf 'bash %s\n' "$(bash --version | head -n1)"
-printf 'zsh %s\n' "$(zsh --version 2>/dev/null | head -n1)"
-printf 'clang %s\n' "$(clang --version 2>/dev/null | head -n1)"
-printf 'lld %s\n' "$(ld.lld --version 2>/dev/null | head -n1)"
-printf 'npm %s\n' "$(npm -v 2>/dev/null)"
-printf 'node %s\n' "$(node -v 2>/dev/null)"
 printf 'python %s\n' "$(python -V 2>&1)"
 printf 'shellcheck %s\n' "$(shellcheck --version 2>/dev/null | head -n1)"
 for t in "${tests[@]}"; do


### PR DESCRIPTION
## Summary
- stop existing squid service before initialization
- reinitialize SSL DB for clean start

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh`
- `squid-cache/tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aee1edb7ec832db8da1a44fdae1a3e