### PR TITLE
refactor: separate SSL DB base directory creation

### DIFF
--- a/squid-cache/squid-cache.sh
+++ b/squid-cache/squid-cache.sh
@@ -21,7 +21,8 @@ CA_PEM="$CA_DIR/ca.pem"
 CA_TRUST_NAME="squid-mitm"
 CA_DAYS="3650"
 CA_SUBJ="/CN=$HOSTNAME_TAG/O=$HOSTNAME_TAG/L=Local/C=NA"
-SSL_DB_DIR="${TMPDIR:-$(mktemp -d)}/ssl_db"
+SSL_DB_BASE="${TMPDIR:-$(mktemp -d)}"
+SSL_DB_DIR="$SSL_DB_BASE/ssl_db"
 CACHE_IF_STANDALONE_BIN="$BASE_DIR/squid-cache"
 CACHE_IF_SYSTEM="/tmp/squid-cache"
 SQUID_BIN_SYSTEM="/usr/sbin/squid"
@@ -44,7 +45,8 @@ ensure_dirs() {
 
 prepare_ssl_db_dir() {
   rm -rf "$SSL_DB_DIR"
-  install -d -o "$SQUID_USER" -g "$SQUID_GROUP" "$SSL_DB_DIR" || { echo "cannot create ssl db dir $SSL_DB_DIR"; rm -f "$LOCK_FILE"; exit 1; }
+  install -d -m 0755 -o "$SQUID_USER" -g "$SQUID_GROUP" "$SSL_DB_BASE" || { echo "cannot create ssl db dir $SSL_DB_BASE"; rm -f "$LOCK_FILE"; exit 1; }
+  install -d -m 0755 -o "$SQUID_USER" -g "$SQUID_GROUP" "$SSL_DB_DIR" || { echo "cannot create ssl db dir $SSL_DB_DIR"; rm -f "$LOCK_FILE"; exit 1; }
 }
 
 cache_dir_pick() {


### PR DESCRIPTION
## Summary
- extract temporary base path to SSL_DB_BASE and derive SSL_DB_DIR from it
- create both SSL_DB_BASE and SSL_DB_DIR with proxy ownership and 0755 mode

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh`
- `cd squid-cache/tests && ./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aee8e6a954832d8f94d065ca9a1f2b