### PR TITLE
Log squid service failure with journalctl

### DIFF
--- a/squid-cache/tests/00_start_iptables_cert.sh
+++ b/squid-cache/tests/00_start_iptables_cert.sh
@@ -4,7 +4,7 @@ if ! command -v systemctl >/dev/null 2>&1; then exit 0; fi
 if ! systemctl is-system-running >/dev/null 2>&1; then exit 0; fi
 if ! command -v iptables >/dev/null 2>&1; then exit 0; fi
 o=$(mktemp)
-bash "$SQUID" start >"$o"
+bash "$SQUID" start >"$o" || { journalctl -xeu squid.service; exit 1; }
 [ "$(tail -n1 "$o")" = started ]
 iptables -t nat -S | grep -q SQUID_LOCAL
 [ -f /usr/local/share/ca-certificates/squid-mitm.crt ]


### PR DESCRIPTION
## Summary
- Add `journalctl` output when starting squid fails to clarify service errors

## Testing
- `shellcheck -e SC1091,SC2154,SC2034,SC2086,SC2015 osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh squid-cache/tests/00_start_iptables_cert.sh && echo shellcheck_ok`
- `squid-cache/tests/run-tests.sh squid-cache/tests/00_start_iptables_cert.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aef4b43654832d809d46076984229f