### PR TITLE
Avoid error when file command is missing in osx-run

### DIFF
--- a/osx-run/osx-run.sh
+++ b/osx-run/osx-run.sh
@@ -64,7 +64,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 EOF3
 printf '#include <stdio.h>\nint main(){puts("ok");}\n' > "$SCRIPT_DIR/t.c"
 PATH="$OSXCROSS_ROOT/target/bin:$PATH" SDKROOT="$(xcrun --show-sdk-path)" MACOSX_DEPLOYMENT_TARGET="$DEPLOY_MIN" xcrun clang -arch arm64 -mmacos-version-min="$DEPLOY_MIN" "$SCRIPT_DIR/t.c" -o "$SCRIPT_DIR/t_arm64"
-file "$SCRIPT_DIR/t_arm64" || true
+command -v file >/dev/null 2>&1 && file "$SCRIPT_DIR/t_arm64" || true
 echo OK
 . "$OSXCROSS_ROOT/env/activate"
 if [ -t 0 ]; then


### PR DESCRIPTION
## Summary
- check for `file` command before invoking in osx-run

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh`
- `./osx-run/tests/run-tests.sh osx-run/tests/13_shellcheck_style.sh osx-run/tests/14_run_no_args.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af1f4f8fec832d94a909ce95cee7f5