### PR TITLE
Add environment assertion utilities

### DIFF
--- a/squid-cache/tests/00_start_iptables_cert.sh
+++ b/squid-cache/tests/00_start_iptables_cert.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-if ! command -v iptables >/dev/null 2>&1; then exit 0; fi
-iptables -t nat -L >/dev/null 2>&1 || exit 0
+. "$(dirname "$0")/../../testing/assert.sh"
+assert_cmd iptables
+assert_env SQUID
+iptables -t nat -L >/dev/null 2>&1
 o=$(mktemp)
 base=$(dirname "$SQUID")
 bash "$SQUID" start >"$o" || exit 1
 [ "$(tail -n1 "$o")" = started ]
 iptables -t nat -S | grep -q SQUID_LOCAL
-[ -f "$base/mitm_ca/ca.crt" ]
-[ -f /usr/local/share/ca-certificates/squid-mitm.crt ]
+assert_file "$base/mitm_ca/ca.crt"
+assert_file /usr/local/share/ca-certificates/squid-mitm.crt
 bash "$SQUID" stop >"$o"
 [ "$(tail -n1 "$o")" = stopped ]
 [ ! -f /usr/local/share/ca-certificates/squid-mitm.crt ]

--- a/testing/AGENTS.md
+++ b/testing/AGENTS.md
@@ -1,0 +1,4 @@
+Source assert.sh for environment checks in tests.
+assert_cmd fails if a command is missing.
+assert_file fails if a file is absent.
+assert_env fails if an environment variable is unset.

--- a/testing/assert.sh
+++ b/testing/assert.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+assert_cmd(){ command -v "$1" >/dev/null 2>&1 || { printf '%s missing\n' "$1" >&2; exit 1; }; }
+assert_file(){ [ -f "$1" ] || { printf '%s missing\n' "$1" >&2; exit 1; }; }
+assert_env(){ [ -n "${!1:-}" ] || { printf '%s missing\n' "$1" >&2; exit 1; }; }


### PR DESCRIPTION
## Summary
- revert timeout-based changes in squid-cache test
- introduce reusable assert.sh for environment checks
- validate iptables and required files in squid-cache test

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh squid-cache/tests/*.sh testing/assert.sh`
- `cd squid-cache/tests && ./run-tests.sh ./00_start_iptables_cert.sh` *(fails: iptables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af1fc5bf40832dbd5844d7335873fb