### PR TITLE
Use static assert path in squid-cache test

### DIFF
--- a/squid-cache/tests/00_start_iptables_cert.sh
+++ b/squid-cache/tests/00_start_iptables_cert.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-. "$(dirname "$0")/../../testing/assert.sh"
+cd "$(dirname "$0")"
+. ../../testing/assert.sh
 assert_cmd iptables
 assert_env SQUID
 iptables -t nat -L >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- resolve assert.sh via static relative path in test

## Testing
- `shellcheck -x -P SCRIPTDIR squid-cache/squid-cache.sh squid-cache/tests/*.sh`
- `./squid-cache/tests/run-tests.sh` *(fails: iptables v1.8.10 (nf_tables): Could not fetch rule set generation id: Permission denied (you must be root))*

------
https://chatgpt.com/codex/tasks/task_e_68af29085e18832d8b58386e50c517b4