### PR TITLE
Source assert from repository root in squid test

### DIFF
--- a/.github/workflows/squid-cache-tests.yml
+++ b/.github/workflows/squid-cache-tests.yml
@@ -9,7 +9,7 @@ jobs:
     - run: sudo apt-get update && sudo apt-get install -y shellcheck iptables zsh lld
     - run: sudo ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables
     - name: shellcheck
-      run: shellcheck squid-cache/squid-cache.sh squid-cache/tests/*.sh
+      run: shellcheck squid-cache/squid-cache.sh squid-cache/tests/*.sh testing/assert.sh
     - name: run tests
       run: |
         set -e

--- a/squid-cache/tests/00_start_iptables_cert.sh
+++ b/squid-cache/tests/00_start_iptables_cert.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-. "$(dirname "$0")/../../testing/assert.sh"
+. "$PWD/testing/assert.sh"
 assert_cmd iptables
 assert_env SQUID
 iptables -t nat -L >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- source testing/assert.sh from repository root in squid-cache test
- include testing/assert.sh in shellcheck workflow

## Testing
- `shellcheck -x -e SC1091,SC2015 osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh squid-cache/tests/*.sh testing/assert.sh`
- `./squid-cache/tests/run-tests.sh` *(fails: iptables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af29085e18832d8b58386e50c517b4