### PR TITLE
feat: gate interactive shell with env

### DIFF
--- a/osx-run/osx-run.sh
+++ b/osx-run/osx-run.sh
@@ -13,7 +13,7 @@ cd "$SCRIPT_DIR"
 : "${ARCHES:=arm64}"
 : "${XCODE_XIP:=}"
 : "${SDK_TARBALL_URL:=}"
-export DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
 /usr/bin/sudo apt-get update
 /usr/bin/sudo apt-get install -y build-essential clang lld cmake git patch python3 xz-utils curl libssl-dev liblzma-dev libxml2-dev bzip2 cpio zlib1g-dev uuid-dev ninja-build pkg-config ca-certificates
 f=""
@@ -64,10 +64,10 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 EOF3
 printf '#include <stdio.h>\nint main(){puts("ok");}\n' > "$SCRIPT_DIR/t.c"
 PATH="$OSXCROSS_ROOT/target/bin:$PATH" SDKROOT="$(xcrun --show-sdk-path)" MACOSX_DEPLOYMENT_TARGET="$DEPLOY_MIN" xcrun clang -arch arm64 -mmacos-version-min="$DEPLOY_MIN" "$SCRIPT_DIR/t.c" -o "$SCRIPT_DIR/t_arm64"
-command -v file >/dev/null 2>&1 && file "$SCRIPT_DIR/t_arm64" || true
+if command -v file >/dev/null 2>&1; then file "$SCRIPT_DIR/t_arm64"; fi
 echo OK
 . "$OSXCROSS_ROOT/env/activate"
-if [ -t 0 ]; then
+if [ -t 0 ] && [ -z "${OSX_RUN_SKIP_SHELL:-}" ]; then
 SHELL_BIN="${SHELL:-/bin/bash}"
 exec "$SHELL_BIN" -i
 fi
@@ -84,7 +84,7 @@ SITEDIR="$OSX_ROOT/site-$PLATFORM"
 export WHEELHOUSE
 path_prepend_unique() {
  d="$1"
- [ -n "$d" ] && [ -d "$d" ] || return 0
+ if [ -z "$d" ] || [ ! -d "$d" ]; then return 0; fi
  case ":$PATH:" in *":$d:"*) ;; *) PATH="$d:$PATH" ;; esac
 }
 pick_latest_dir() {

--- a/osx-run/tests/run-tests.sh
+++ b/osx-run/tests/run-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+export OSX_RUN_SKIP_SHELL=1
 stub_env(){
  OSX_ROOT="$1"
  mkdir -p "$OSX_ROOT/bin" "$OSX_ROOT/env" "$OSX_ROOT/shims" "$OSX_ROOT/pkgs/osxcross/target/bin" "$OSX_ROOT/pkgs/osxcross/target/SDK" "$OSX_ROOT/pkgs/python/3.12.0/bin" "$OSX_ROOT/pkgs/node/22.7.0/bin" "$OSX_ROOT/wheelhouse/macosx_15_0_arm64" "$OSX_ROOT/site-macosx_15_0_arm64" "$OSX_ROOT/cache" "$OSX_ROOT/toolchains"

--- a/squid-cache/squid-cache.sh
+++ b/squid-cache/squid-cache.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
 
 ACTION="${1:-}"
 BASE_DIR="$(cd "$(dirname "$0")" && pwd -P)"


### PR DESCRIPTION
## Summary
- add env-controlled gate to prevent spawning interactive shell in osx-run
- ensure apt runs non-interactively in squid-cache
- expose skip-shell flag in osx-run tests

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh`
- `osx-run/tests/run-tests.sh` *(fails: Unexpected EOF in MacOSX15.5.sdk.tar.xz)*
- `squid-cache/tests/run-tests.sh` *(fails: iptables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af33ca6008832d95c6ef1228061ef1