### PR TITLE
Capture test output to tmp and filter trace

### DIFF
--- a/lib/testing/utils.sh
+++ b/lib/testing/utils.sh
@@ -3,7 +3,8 @@ set -Eeuo pipefail
 run(){
  log="$1"
  shift
- exec 3>&1
- "$@" >"$log" 2>&1
+ base=$(basename "$log")
+ tmp="/tmp/$base"
+ "$@" 2>&1 | tee "$tmp" | tee "$log" | sed '/^+/d'
+ return "${PIPESTATUS[0]}"
 }
-"$@"

--- a/osx-run/tests/run-tests.sh
+++ b/osx-run/tests/run-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+. "$PWD/lib/testing/utils.sh"
 export OSX_RUN_SKIP_SHELL=1
 stub_env(){
  OSX_ROOT="$1"
@@ -101,7 +102,7 @@ cp "$dir/../osx-run.sh" "$tmp_run"
 RUN="$tmp_run/osx-run.sh"
 chmod +x "$RUN"
 export RUN
-run(){
+test_run(){
  t="$1"
  name=$(basename "$t")
  log="$dir/../../artifacts/${name%.sh}.log"
@@ -112,14 +113,14 @@ run(){
  export OSX_ROOT HOME
  stub_env "$OSX_ROOT"
  echo "$name START"
- if "$dir/../../lib/testing/utils.sh" run "$log" bash -x "$t"; then
+ if run "$log" bash -x "$t"; then
   echo "$name PASS"
   pass=$((pass+1))
-  [ -n "${TRACE:-}" ] && cat "$log"
+  [ -n "${TRACE:-}" ] && cat "/tmp/${name%.sh}.log"
  else
   echo "$name FAIL"
   fail=$((fail+1))
-  cat "$log"
+  echo "/tmp/${name%.sh}.log"
  fi
  rm -rf "$work" "$home"
 }
@@ -145,7 +146,7 @@ printf 'node %s\n' "$(node -v 2>/dev/null)"
 printf 'python %s\n' "$(python -V 2>&1)"
 printf 'shellcheck %s\n' "$(shellcheck --version 2>/dev/null | head -n1)"
 for t in "${tests[@]}"; do
- run "$t"
+ test_run "$t"
 done
 echo "passed $pass failed $fail"
 rm -rf "$tmp_run"

--- a/squid-cache/tests/run-tests.sh
+++ b/squid-cache/tests/run-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+. "$PWD/lib/testing/utils.sh"
 pass=0
 fail=0
 dir=$(cd "$(dirname "$0")" && pwd)
@@ -9,7 +10,7 @@ cp "$dir/../squid-cache.sh" "$tmp_run"
 SQUID="$tmp_run/squid-cache.sh"
 chmod +x "$SQUID"
 export SQUID
-run(){
+test_run(){
  t="$1"
  name=$(basename "$t")
  log="$dir/../../artifacts/${name%.sh}.log"
@@ -20,14 +21,14 @@ run(){
  export OSX_ROOT HOME
  mkdir -p "$OSX_ROOT"
  echo "$name START"
- if "$dir/../../lib/testing/utils.sh" run "$log" bash -x "$t"; then
+ if run "$log" bash -x "$t"; then
   echo "$name PASS"
   pass=$((pass+1))
-  [ -n "${TRACE:-}" ] && cat "$log"
+  [ -n "${TRACE:-}" ] && cat "/tmp/${name%.sh}.log"
  else
   echo "$name FAIL"
   fail=$((fail+1))
-  cat "$log"
+  echo "/tmp/${name%.sh}.log"
  fi
  rm -rf "$work" "$home"
 }
@@ -48,7 +49,7 @@ printf 'bash %s\n' "$(bash --version | head -n1)"
 printf 'python %s\n' "$(python -V 2>&1)"
 printf 'shellcheck %s\n' "$(shellcheck --version 2>/dev/null | head -n1)"
 for t in "${tests[@]}"; do
- run "$t"
+ test_run "$t"
 done
 echo "passed $pass failed $fail"
 rm -rf "$tmp_run"


### PR DESCRIPTION
## Summary
- record raw test output to `/tmp/<name>.log`
- show test output without bash trace
- point to trace log on failure
- centralize test output helper under `lib/testing`

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh lib/testing/utils.sh`
- `osx-run/tests/run-tests.sh osx-run/tests/14_run_no_args.sh`
- `squid-cache/tests/run-tests.sh squid-cache/tests/00_start_iptables_cert.sh` *(fails: iptables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af4132564c832d9dc5e952213fbf04