### PR TITLE
Document testing logs and clarify osx-run usage

### DIFF
--- a/lib/testing/AGENTS.md
+++ b/lib/testing/AGENTS.md
@@ -1,0 +1,1 @@
+Console output omits trace lines; traced logs are written automatically to /tmp/<name>.log at a fixed path.

--- a/osx-run/AGENTS.md
+++ b/osx-run/AGENTS.md
@@ -1,2 +1,7 @@
 - osx-run.sh is bash with set -Eeuo pipefail and no comments
 - env-setup.txt lists commands to fetch resources and install osxcross, Python 3.11, and Node 22 with osx-run.sh
+- install osxcross pulls build-essential, clang, lld, cmake, git, patch, python3, xz-utils, curl, libssl-dev, liblzma-dev, libxml2-dev, bzip2, cpio, zlib1g-dev, uuid-dev, ninja-build, pkg-config, ca-certificates, and ld64.lld
+- the environment uses osxcross to emulate macOS so tools produce Darwin binaries
+- run ./osx-run.sh install osxcross to build the toolchain under \$OSX_ROOT; install python or node with ./osx-run.sh install python `<ver>` and ./osx-run.sh install node `<ver>`
+- invoking osx-run.sh `<command>` executes the command inside a macOS-like environment; examples: ./osx-run.sh xcrun clang --version, ./osx-run.sh python3 -V, ./osx-run.sh npm --version
+- calling osx-run.sh without arguments configures PATH so subsequent shells use the macOS-targeting toolchain

--- a/squid-cache/tests/run-tests.sh
+++ b/squid-cache/tests/run-tests.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-. "$PWD/lib/testing/utils.sh"
+dir="${BASH_SOURCE[0]%/*}"
+. "$dir/../../lib/testing/utils.sh"
 pass=0
 fail=0
-dir=$(cd "$(dirname "$0")" && pwd)
+dir=$(cd "$dir" && pwd)
 mkdir -p "$dir/../../artifacts"
 tmp_run=$(mktemp -d)
 cp "$dir/../squid-cache.sh" "$tmp_run"
@@ -14,6 +15,7 @@ test_run(){
  t="$1"
  name=$(basename "$t")
  log="$dir/../../artifacts/${name%.sh}.log"
+ trace="/tmp/${name%.sh}.log"
  work=$(mktemp -d)
  home=$(mktemp -d)
  OSX_ROOT="$work/opt/osx"
@@ -21,7 +23,7 @@ test_run(){
  export OSX_ROOT HOME
  mkdir -p "$OSX_ROOT"
  echo "$name START"
- if run "$log" bash -x "$t"; then
+ if run "$log" bash -x "$t" 3>>"$trace"; then
   echo "$name PASS"
   pass=$((pass+1))
   [ -n "${TRACE:-}" ] && cat "/tmp/${name%.sh}.log"


### PR DESCRIPTION
## Summary
- document macOS emulation and command usage in osx-run instructions
- open file descriptor 3 for test runs to avoid Bad file descriptor

## Testing
- `shellcheck squid-cache/squid-cache.sh squid-cache/tests/*.sh testing/assert.sh lib/testing/utils.sh`
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh`
- `bash squid-cache/tests/run-tests.sh` *(fails: iptables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af4815fdf0832db353f3f18ccddb72