### PR TITLE
Improve osx-run python version resolution

### DIFF
--- a/osx-run/tests/05_python_install_version.sh
+++ b/osx-run/tests/05_python_install_version.sh
@@ -2,4 +2,10 @@
 set -Eeuo pipefail
 "$RUN" install python 3.12 >/dev/null
 "$RUN" python -c 'import sys;print(sys.version)' | grep -q '^3\.12\.'
+mkdir -p "$OSX_ROOT/pkgs/python/3.11.0/bin"
+printf '#!/usr/bin/env bash\n' > "$OSX_ROOT/pkgs/python/3.11.0/bin/python3"
+chmod +x "$OSX_ROOT/pkgs/python/3.11.0/bin/python3"
+ln -sf "$OSX_ROOT/pkgs/python/3.11.0/bin/python3" "$OSX_ROOT/pkgs/python/3.11.0/bin/python"
+"$RUN" install python 3.11.0 >/dev/null
+[ "$(readlink -f "$OSX_ROOT/pkgs/python/current")" = "$OSX_ROOT/pkgs/python/3.11.0" ]
 grep -q "$OSX_ROOT/site-" "$OSX_ROOT/env/pip-macos.conf"


### PR DESCRIPTION
## Summary
- robustly resolve Python patch versions and avoid missing packages
- cover Python version handling in tests

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh`
- `osx-run/tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68af4b32a8d0832da3f2b196a5ee70e7