### PR TITLE
Fix Python installer extraction and document Automake target

### DIFF
--- a/osx-run/AGENTS.md
+++ b/osx-run/AGENTS.md
@@ -5,3 +5,4 @@
 - run ./osx-run.sh install osxcross to build the toolchain under \$OSX_ROOT; install python or node with ./osx-run.sh install python `<ver>` and ./osx-run.sh install node `<ver>`
 - invoking osx-run.sh `<command>` executes the command inside a macOS-like environment; examples: ./osx-run.sh xcrun clang --version, ./osx-run.sh python3 -V, ./osx-run.sh npm --version
 - calling osx-run.sh without arguments configures PATH so subsequent shells use the macOS-targeting toolchain
+- for Automake projects use aarch64-apple-darwin24.5-* instead of arm64-* and run CC=aarch64-apple-darwin24.5-clang ./configure --host=aarch64-apple-darwin24.5

--- a/osx-run/osx-run.sh
+++ b/osx-run/osx-run.sh
@@ -93,13 +93,15 @@ case "$ver" in
 esac
 dir="$OSX_ROOT/pkgs/python/$fv"
 if [ ! -x "$dir/bin/python3" ]; then
+command -v 7z >/dev/null 2>&1 || /usr/bin/sudo apt-get install -y p7zip-full
 command -v bsdtar >/dev/null 2>&1 || /usr/bin/sudo apt-get install -y libarchive-tools
-mkdir -p "$dir"
+mkdir -p "$(dirname "$dir")"
 curl -fL "https://www.python.org/ftp/python/$fv/python-$fv-macos11.pkg" -o "$OSX_ROOT/cache/python-$fv.pkg"
 tmp="$(mktemp -d)"
-bsdtar -xf "$OSX_ROOT/cache/python-$fv.pkg" -C "$tmp"
+7z x "$OSX_ROOT/cache/python-$fv.pkg" -o"$tmp" >/dev/null
+rm -rf "$tmp/Resources"
 bsdtar -xf "$tmp/Python_Framework.pkg/Payload" -C "$tmp"
-mv "$tmp/Library/Frameworks/Python.framework/Versions/$fv" "$dir"
+mv "$tmp/Versions/${fv%.*}" "$dir"
 ln -sf "$dir/bin/python3" "$dir/bin/python"
 rm -rf "$tmp"
 fi


### PR DESCRIPTION
## Summary
- fix macOS Python package extraction using 7z and correct framework path
- document Automake aarch64-apple-darwin24.5* toolchain usage

## Testing
- `shellcheck osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh`
- `./osx-run/tests/run-tests.sh`
- `tmpdir=$(mktemp -d); OSX_ROOT=$tmpdir ./osx-run/osx-run.sh install python 3.11.9`

------
https://chatgpt.com/codex/tasks/task_e_68af4fd782fc832d83b136a58b22683c