### PR TITLE
docs: add iptables test instructions

### DIFF
--- a/squid-cache/tests/AGENTS.md
+++ b/squid-cache/tests/AGENTS.md
@@ -2,3 +2,6 @@
 - Scripts are bash with set -Eeuo pipefail and no comments
 - Run ./run-tests.sh to execute all tests or pass script paths
 - Tests check startup iptables certificate caching and python download
+- iptables is not installed by default; install before running tests:
+  - sudo apt-get update && sudo apt-get install -y iptables
+  - sudo ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables


### PR DESCRIPTION
## Summary
- document iptables installation requirement for squid-cache tests

## Testing
- `shellcheck -x osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh` *(fails: SC1091)
- `(cd squid-cache/tests && ./run-tests.sh)` *(fails: /workspace/DevOpsKit/squid-cache/tests/testing/assert.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af52baf904832d89a35496f54a7bb3