### PR TITLE
Remove osx-run cache and add squid tcpdump test

### DIFF
--- a/osx-run/osx-run.sh
+++ b/osx-run/osx-run.sh
@@ -84,7 +84,6 @@ if [ "${1:-}" = install ] && [ "${2:-}" = python ]; then
 : "${OSX_ROOT:=/opt/osx}"
 ver="${3:-3.11}"
 for d in "$OSX_ROOT/pkgs/python/$ver" "$OSX_ROOT/pkgs/python/$ver"*; do [ -d "$d" ] && { ln -sfn "$d" "$OSX_ROOT/pkgs/python/current"; exit 0; }; done
-mkdir -p "$OSX_ROOT/cache"
 lst="$(curl -fsL https://www.python.org/ftp/python/)"
 case "$ver" in
 *.*.*) fv="$ver" ;;
@@ -96,9 +95,9 @@ if [ ! -x "$dir/bin/python3" ]; then
 command -v 7z >/dev/null 2>&1 || /usr/bin/sudo apt-get install -y p7zip-full
 command -v bsdtar >/dev/null 2>&1 || /usr/bin/sudo apt-get install -y libarchive-tools
 mkdir -p "$(dirname "$dir")"
-curl -fL "https://www.python.org/ftp/python/$fv/python-$fv-macos11.pkg" -o "$OSX_ROOT/cache/python-$fv.pkg"
 tmp="$(mktemp -d)"
-7z x "$OSX_ROOT/cache/python-$fv.pkg" -o"$tmp" >/dev/null
+curl -fL "https://www.python.org/ftp/python/$fv/python-$fv-macos11.pkg" -o "$tmp/pkg"
+7z x "$tmp/pkg" -o"$tmp" >/dev/null
 rm -rf "$tmp/Resources"
 bsdtar -xf "$tmp/Python_Framework.pkg/Payload" -C "$tmp"
 mv "$tmp/Versions/${fv%.*}" "$dir"
@@ -113,13 +112,14 @@ if [ "${1:-}" = install ] && [ "${2:-}" = node ]; then
 : "${DEFAULT_ARCH:=arm64}"
 ver="${3:-22}"
 for d in "$OSX_ROOT/pkgs/node/$ver"*; do [ -d "$d" ] && { ln -sfn "$d" "$OSX_ROOT/pkgs/node/current"; exit 0; }; done
-mkdir -p "$OSX_ROOT/cache"
 fv="$(curl -fsL https://nodejs.org/dist/index.json | grep -o "v${ver}[0-9.]*" | head -n1 | tr -d v)"
 dir="$OSX_ROOT/pkgs/node/$fv"
 if [ ! -x "$dir/bin/node" ]; then
 mkdir -p "$dir"
-curl -fL "https://nodejs.org/dist/v$fv/node-v$fv-darwin-$DEFAULT_ARCH.tar.gz" -o "$OSX_ROOT/cache/node-v$fv-darwin-$DEFAULT_ARCH.tar.gz"
-tar -xzf "$OSX_ROOT/cache/node-v$fv-darwin-$DEFAULT_ARCH.tar.gz" -C "$dir" --strip-components 1
+tmp="$(mktemp -d)"
+curl -fL "https://nodejs.org/dist/v$fv/node-v$fv-darwin-$DEFAULT_ARCH.tar.gz" -o "$tmp/node.tar.gz"
+tar -xzf "$tmp/node.tar.gz" -C "$dir" --strip-components 1
+rm -rf "$tmp"
 fi
 ln -sfn "$dir" "$OSX_ROOT/pkgs/node/current"
 exit 0

--- a/osx-run/tests/00_bootstrap_skeleton.sh
+++ b/osx-run/tests/00_bootstrap_skeleton.sh
@@ -8,7 +8,6 @@ set -Eeuo pipefail
 [ -d "$OSX_ROOT/env" ]
 [ -d "$OSX_ROOT/shims" ]
 [ -d "$OSX_ROOT/pkgs" ]
-[ -d "$OSX_ROOT/cache" ]
 [ -d "$OSX_ROOT/wheelhouse" ]
 count=$(find "$OSX_ROOT" -maxdepth 1 -type d -name 'site-*' | wc -l)
 test "$count" -ge 1

--- a/osx-run/tests/run-tests.sh
+++ b/osx-run/tests/run-tests.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 export OSX_RUN_SKIP_SHELL=1
 stub_env(){
  OSX_ROOT="$1"
- mkdir -p "$OSX_ROOT/bin" "$OSX_ROOT/env" "$OSX_ROOT/shims" "$OSX_ROOT/pkgs/osxcross/target/bin" "$OSX_ROOT/pkgs/osxcross/target/SDK" "$OSX_ROOT/pkgs/python/3.12.0/bin" "$OSX_ROOT/pkgs/node/22.7.0/bin" "$OSX_ROOT/wheelhouse/macosx_15_0_arm64" "$OSX_ROOT/site-macosx_15_0_arm64" "$OSX_ROOT/cache" "$OSX_ROOT/toolchains"
+ mkdir -p "$OSX_ROOT/bin" "$OSX_ROOT/env" "$OSX_ROOT/shims" "$OSX_ROOT/pkgs/osxcross/target/bin" "$OSX_ROOT/pkgs/osxcross/target/SDK" "$OSX_ROOT/pkgs/python/3.12.0/bin" "$OSX_ROOT/pkgs/node/22.7.0/bin" "$OSX_ROOT/wheelhouse/macosx_15_0_arm64" "$OSX_ROOT/site-macosx_15_0_arm64" "$OSX_ROOT/toolchains"
  cat > "$OSX_ROOT/bin/install" <<'EOF2'
 #!/usr/bin/env bash
 exit 0

--- a/squid-cache/squid-cache.sh
+++ b/squid-cache/squid-cache.sh
@@ -187,7 +187,8 @@ iptables_disable() {
     while iptables -t nat -S "$IPTABLES_CHAIN" | grep -q "^-A $IPTABLES_CHAIN"; do
       local rule
       rule="$(iptables -t nat -S "$IPTABLES_CHAIN" | grep "^-A $IPTABLES_CHAIN" | head -n1 | sed 's/^-A /-D /')"
-      iptables -t nat "$rule" || true
+      read -r -a parts <<< "$rule"
+      iptables -t nat "${parts[@]}" || true
     done
     iptables -t nat -X "$IPTABLES_CHAIN" || true
   fi

--- a/squid-cache/tests/03_tcpdump.sh
+++ b/squid-cache/tests/03_tcpdump.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+. "$PWD/testing/assert.sh"
+assert_cmd iptables
+assert_cmd tcpdump
+assert_cmd curl
+assert_env SQUID
+o=$(mktemp)
+bash "$SQUID" start >"$o"
+[ "$(tail -n1 "$o")" = started ]
+tmp=$(mktemp)
+timeout 5 tcpdump -n -i lo port 3128 -c 1 >"$tmp" &
+p=$!
+sleep 1
+curl -L -o /dev/null http://example.com >&3
+wait $p
+grep -q 3128 "$tmp"
+bash "$SQUID" stop >"$o"
+[ "$(tail -n1 "$o")" = stopped ]
+rm -f "$tmp"

--- a/testing/assert.sh
+++ b/testing/assert.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-assert_cmd(){ command -v "$1" >/dev/null 2>&1 || { printf '%s missing\n' "$1" >&2; exit 1; }; }
-assert_file(){ [ -f "$1" ] || { printf '%s missing\n' "$1" >&2; exit 1; }; }
-assert_env(){ [ -n "${!1:-}" ] || { printf '%s missing\n' "$1" >&2; exit 1; }; }
+assert_cmd(){ command -v "$1" >/dev/null 2>&1 || { printf '%s missing\n' "$1" >&2; return 1; }; }
+assert_file(){ [ -f "$1" ] || { printf '%s missing\n' "$1" >&2; return 1; }; }
+assert_env(){ [ -n "${!1:-}" ] || { printf '%s missing\n' "$1" >&2; return 1; }; }


### PR DESCRIPTION
## Summary
- drop osx-run cache usage and adjust tests
- fix iptables rule handling
- add tcpdump integration test for squid

## Testing
- `./osx-run/tests/run-tests.sh`
- `./squid-cache/tests/run-tests.sh` *(fails: iptables v1.8.10 (legacy): can't initialize iptables table 'nat': Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68af4f604ccc832db68ac228fb8a6088