### PR TITLE
Remove osx-run cache and add squid tcpdump test

### DIFF
--- a/osx-run/tests/00_bootstrap_skeleton.sh
+++ b/osx-run/tests/00_bootstrap_skeleton.sh
@@ -8,7 +8,6 @@ set -Eeuo pipefail
 [ -d "$OSX_ROOT/env" ]
 [ -d "$OSX_ROOT/shims" ]
 [ -d "$OSX_ROOT/pkgs" ]
-[ -d "$OSX_ROOT/cache" ]
 [ -d "$OSX_ROOT/wheelhouse" ]
 count=$(find "$OSX_ROOT" -maxdepth 1 -type d -name 'site-*' | wc -l)
 test "$count" -ge 1

--- a/osx-run/tests/run-tests.sh
+++ b/osx-run/tests/run-tests.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 export OSX_RUN_SKIP_SHELL=1
 stub_env(){
  OSX_ROOT="$1"
- mkdir -p "$OSX_ROOT/bin" "$OSX_ROOT/env" "$OSX_ROOT/shims" "$OSX_ROOT/pkgs/osxcross/target/bin" "$OSX_ROOT/pkgs/osxcross/target/SDK" "$OSX_ROOT/pkgs/python/3.12.0/bin" "$OSX_ROOT/pkgs/node/22.7.0/bin" "$OSX_ROOT/wheelhouse/macosx_15_0_arm64" "$OSX_ROOT/site-macosx_15_0_arm64" "$OSX_ROOT/cache" "$OSX_ROOT/toolchains"
+ mkdir -p "$OSX_ROOT/bin" "$OSX_ROOT/env" "$OSX_ROOT/shims" "$OSX_ROOT/pkgs/osxcross/target/bin" "$OSX_ROOT/pkgs/osxcross/target/SDK" "$OSX_ROOT/pkgs/python/3.12.0/bin" "$OSX_ROOT/pkgs/node/22.7.0/bin" "$OSX_ROOT/wheelhouse/macosx_15_0_arm64" "$OSX_ROOT/site-macosx_15_0_arm64" "$OSX_ROOT/toolchains"
  cat > "$OSX_ROOT/bin/install" <<'EOF2'
 #!/usr/bin/env bash
 exit 0

--- a/squid-cache/squid-cache.sh
+++ b/squid-cache/squid-cache.sh
@@ -48,6 +48,7 @@ ensure_dirs() {
 
 prepare_ssl_db_dir() {
   local helper="$1"
+  rm -rf "$SSL_DB_DIR"
   "$helper" -c -s "$SSL_DB_DIR" -M 20MB
   chown -R "$SQUID_USER:$SQUID_GROUP" "$SSL_DB_DIR"
 }
@@ -187,7 +188,8 @@ iptables_disable() {
     while iptables -t nat -S "$IPTABLES_CHAIN" | grep -q "^-A $IPTABLES_CHAIN"; do
       local rule
       rule="$(iptables -t nat -S "$IPTABLES_CHAIN" | grep "^-A $IPTABLES_CHAIN" | head -n1 | sed 's/^-A /-D /')"
-      iptables -t nat "$rule" || true
+      read -r -a parts <<< "$rule"
+      iptables -t nat "${parts[@]}" || true
     done
     iptables -t nat -X "$IPTABLES_CHAIN" || true
   fi

--- a/squid-cache/tests/03_tcpdump.sh
+++ b/squid-cache/tests/03_tcpdump.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+. "$PWD/testing/assert.sh"
+assert_cmd iptables
+assert_cmd tcpdump
+assert_cmd curl
+assert_env SQUID
+o=$(mktemp)
+bash "$SQUID" start >"$o"
+[ "$(tail -n1 "$o")" = started ]
+tmp=$(mktemp)
+timeout 5 tcpdump -n -i lo port 3128 -c 1 >"$tmp" &
+p=$!
+sleep 1
+curl -4 -L -o /dev/null http://example.com >&3
+wait $p
+grep -q 3128 "$tmp"
+bash "$SQUID" stop >"$o"
+[ "$(tail -n1 "$o")" = stopped ]
+rm -f "$tmp"

--- a/squid-cache/tests/run-tests.sh
+++ b/squid-cache/tests/run-tests.sh
@@ -11,6 +11,9 @@ cp "$dir/../squid-cache.sh" "$tmp_run"
 SQUID="$tmp_run/squid-cache.sh"
 chmod +x "$SQUID"
 export SQUID
+apt-get update -y
+apt-get install -y iptables tcpdump
+ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables
 test_run(){
  t="$1"
  name=$(basename "$t")

--- a/testing/assert.sh
+++ b/testing/assert.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-assert_cmd(){ command -v "$1" >/dev/null 2>&1 || { printf '%s missing\n' "$1" >&2; exit 1; }; }
-assert_file(){ [ -f "$1" ] || { printf '%s missing\n' "$1" >&2; exit 1; }; }
-assert_env(){ [ -n "${!1:-}" ] || { printf '%s missing\n' "$1" >&2; exit 1; }; }
+assert_cmd(){ command -v "$1" >/dev/null 2>&1 || { printf '%s missing\n' "$1" >&2; return 1; }; }
+assert_file(){ [ -f "$1" ] || { printf '%s missing\n' "$1" >&2; return 1; }; }
+assert_env(){ [ -n "${!1:-}" ] || { printf '%s missing\n' "$1" >&2; return 1; }; }


### PR DESCRIPTION
## Summary
- remove osx-run cache usage and adjust tests
- fix iptables rule handling
- add tcpdump integration test for squid
- install iptables and tcpdump in squid tests and recreate ssl db each run

## Testing
- `shellcheck -S warning osx-run/osx-run.sh osx-run/tests/*.sh squid-cache/squid-cache.sh squid-cache/tests/run-tests.sh squid-cache/tests/03_tcpdump.sh`
- `./osx-run/tests/run-tests.sh`
- `./squid-cache/tests/run-tests.sh` *(fails: 03_tcpdump.sh FAIL - 0 packets captured; iptables nat permission denied)*
- `iptables -t nat -L` *(fails: iptables v1.8.10 (legacy): can't initialize iptables table `nat`: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68af4f604ccc832db68ac228fb8a6088